### PR TITLE
chore: move map to middle-end and made it responsive

### DIFF
--- a/src/components/Map/index.css
+++ b/src/components/Map/index.css
@@ -1,0 +1,8 @@
+.map_flex {
+  display: flex;
+  justify-content: center;
+  height: 100%;
+  align-items: center;
+  align-content: flex-end;
+  margin-left: 45%;
+}

--- a/src/components/Map/index.jsx
+++ b/src/components/Map/index.jsx
@@ -1,18 +1,30 @@
-import React from 'react';
-import MapGL from 'react-map-gl';
+import React, { useState } from 'react';
+import ReactMapGL from 'react-map-gl';
+import './index.css';
 
-const API_KEY = process.env.REACT_APP_API_KEY;
+const { REACT_APP_API_KEY } = process.env;
 
-const Map = () => (
-  <MapGL
-    width={700}
-    height={450}
-    latitude={37.768}
-    longitude={-122.331}
-    zoom={9.017}
-    mapStyle="mapbox://styles/mapbox/dark-v9"
-    mapboxApiAccessToken={API_KEY}
-  />
-);
+function Map() {
+  const [viewport, setViewport] = useState({
+    latitude: 45.65,
+    longitude: -76.43,
+    width: 700,
+    height: 500,
+    zoom: 10,
+  });
+
+  return (
+    <div className="map_flex">
+      <ReactMapGL
+        {...viewport}
+        mapboxApiAccessToken={REACT_APP_API_KEY}
+        onViewportChange={(viewport) => {
+          setViewport(viewport);
+        }}
+        mapStyle="mapbox://styles/mapbox/dark-v9"
+      />
+    </div>
+  );
+}
 
 export default Map;


### PR DESCRIPTION
- Used flex to make the map's design more responsive
- Move map the middle-end of the page using align-items, and align-content (Note: container height is 100% to move the map freely on the whole page

My webpage should now look like this:

![Capture2](https://user-images.githubusercontent.com/52399476/62060388-b6b37f00-b22d-11e9-9d8f-59dabf05c1a3.PNG)
