### PR TITLE
feat: adding dropdowns to gas/maintenance/paint shops pages

### DIFF
--- a/src/components/Garage/index.jsx
+++ b/src/components/Garage/index.jsx
@@ -1,10 +1,19 @@
 import React from 'react';
 import './index.css';
 import Map from '../Map/index';
+import TypeofCars from '../Selectors/Car-Brands';
+import TypeofMaintenance from '../Selectors/Type Of Maintenance';
 
 const Garage = () => (
   <div className="pagestyle_garage">
-    <Map />
+    <div className="flex_container_map">
+
+      <TypeofCars />
+      <TypeofMaintenance />
+
+      <Map />
+    </div>
+
   </div>
 );
 

--- a/src/components/Gas-stations/index.jsx
+++ b/src/components/Gas-stations/index.jsx
@@ -1,10 +1,15 @@
 import React from 'react';
 import './index.css';
 import Map from '../Map/index';
+import TypeofGas from '../Selectors/Gas';
 
 const gasStations = () => (
   <div className="pagestyle_gas">
-    <Map />
+    <div className="flex_container_map">
+      <TypeofGas />
+      <Map />
+    </div>
+
   </div>
 );
 

--- a/src/components/Map/index.css
+++ b/src/components/Map/index.css
@@ -1,8 +1,10 @@
-.map_flex {
+.flex_container_map {
   display: flex;
   justify-content: center;
   height: 100%;
   align-items: center;
-  align-content: flex-end;
-  margin-left: 45%;
+}
+
+.map_margin {
+  margin-left: 250px;
 }

--- a/src/components/Map/index.jsx
+++ b/src/components/Map/index.jsx
@@ -14,7 +14,7 @@ function Map() {
   });
 
   return (
-    <div className="map_flex">
+    <div className="map_margin">
       <ReactMapGL
         {...viewport}
         mapboxApiAccessToken={REACT_APP_API_KEY}

--- a/src/components/Paint-shops/index.jsx
+++ b/src/components/Paint-shops/index.jsx
@@ -1,11 +1,17 @@
 import React from 'react';
 import './index.css';
 import Map from '../Map/index';
+import TypeofPaint from '../Selectors/Type Of Paint';
 
 
 const PaintShops = () => (
   <div className="pagestyle_paint">
-    <Map />
+    <div className="flex_container_map">
+      <TypeofPaint />
+
+      <Map />
+    </div>
+
   </div>
 );
 

--- a/src/components/Selectors/Car-Brands/index.css
+++ b/src/components/Selectors/Car-Brands/index.css
@@ -1,0 +1,41 @@
+.select-css-brands {
+  flex-direction: column;
+  display: block;
+  font-size: 16px;
+  font-family: sans-serif;
+  font-weight: 700;
+  color: rgb(255, 255, 255);
+  line-height: 1.3;
+  padding: 0.6em 1.4em 0.5em 0.8em;
+  width: 275.188px;
+  max-width: 275.188px;
+  box-sizing: border-box;
+  border: 1px solid rgb(0, 0, 0);
+  box-shadow: 0 1px 0 1px rgba(0, 0, 0, 0.04);
+  border-radius: 0.5em;
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  appearance: none;
+  background-color: rgb(0, 0, 0);
+  background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22%23007CB2%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.5-3.5%205.4-7.8%205.4-12.8%200-5-1.9-9.2-5.5-12.8z%22%2F%3E%3C%2Fsvg%3E'),
+    linear-gradient(to bottom, rgb(0, 0, 0) 0%, rgba(27, 82, 184, 0.5) 100%);
+  background-repeat: no-repeat, repeat;
+  background-position: right 0.7em top 50%, 0 0;
+  background-size: 0.65em auto, 100%;
+}
+.select-css::-ms-expand {
+  display: none;
+}
+.select-css:hover {
+  border-color: #888;
+}
+.select-css:focus {
+  border-color: #aaa;
+  box-shadow: 0 0 1px 3px rgba(255, 255, 255, 0.7);
+  box-shadow: 0 0 0 3px -moz-mac-focusring;
+  color: rgb(255, 255, 255);
+  outline: none;
+}
+.select-css option {
+  font-weight: normal;
+}

--- a/src/components/Selectors/Car-Brands/index.jsx
+++ b/src/components/Selectors/Car-Brands/index.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import './index.css';
+
+const TypeofCar = () => (
+  <div>
+    <select className="select-css-brands">
+      <option value="none">Brand</option>
+      <option value="BMW">BMW</option>
+      <option value="Opel">Opel</option>
+      <option value="Honda">Honda</option>
+      <option value="Mercedes">Mercedes</option>
+      <option value="Other">Other</option>
+    </select>
+  </div>
+);
+
+export default TypeofCar;

--- a/src/components/Selectors/Gas/index.css
+++ b/src/components/Selectors/Gas/index.css
@@ -1,0 +1,41 @@
+.select-css-gas {
+  display: block;
+  font-size: 16px;
+  flex-direction: column;
+  font-family: sans-serif;
+  font-weight: 700;
+  color: rgb(255, 255, 255);
+  line-height: 1.3;
+  padding: 0.6em 1.4em 0.5em 0.8em;
+  width: 275.188px;
+  max-width: 275.188px;
+  box-sizing: border-box;
+  border: 1px solid rgb(0, 0, 0);
+  box-shadow: 0 1px 0 1px rgba(0, 0, 0, 0.04);
+  border-radius: 0.5em;
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  appearance: none;
+  background-color: rgb(0, 0, 0);
+  background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22%23007CB2%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.5-3.5%205.4-7.8%205.4-12.8%200-5-1.9-9.2-5.5-12.8z%22%2F%3E%3C%2Fsvg%3E'),
+    linear-gradient(to bottom, rgb(0, 0, 0) 0%, rgba(167, 170, 11, 0.5) 100%);
+  background-repeat: no-repeat, repeat;
+  background-position: right 0.7em top 50%, 0 0;
+  background-size: 0.65em auto, 100%;
+}
+.select-css::-ms-expand {
+  display: none;
+}
+.select-css:hover {
+  border-color: #888;
+}
+.select-css:focus {
+  border-color: #aaa;
+  box-shadow: 0 0 1px 3px rgba(255, 255, 255, 0.7);
+  box-shadow: 0 0 0 3px -moz-mac-focusring;
+  color: rgb(255, 255, 255);
+  outline: none;
+}
+.select-css option {
+  font-weight: normal;
+}

--- a/src/components/Selectors/Gas/index.jsx
+++ b/src/components/Selectors/Gas/index.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import './index.css';
+
+const TypeofGas = () => (
+  <div>
+    <select className="select-css-gas">
+      <option value="none">Select</option>
+      <option value="Refuel">Refuel</option>
+      <option value="Wash">Car Wash</option>
+    </select>
+  </div>
+);
+
+export default TypeofGas;

--- a/src/components/Selectors/Type Of Maintenance/index.css
+++ b/src/components/Selectors/Type Of Maintenance/index.css
@@ -1,0 +1,42 @@
+.select-css-maintenance {
+  margin-left: 50px;
+  display: block;
+  flex-direction: column;
+  font-size: 16px;
+  font-family: sans-serif;
+  font-weight: 700;
+  color: rgb(255, 255, 255);
+  line-height: 1.3;
+  padding: 0.6em 1.4em 0.5em 0.8em;
+  width: 275.188px;
+  max-width: 275.188px;
+  box-sizing: border-box;
+  border: 1px solid rgb(0, 0, 0);
+  box-shadow: 0 1px 0 1px rgba(0, 0, 0, 0.04);
+  border-radius: 0.5em;
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  appearance: none;
+  background-color: rgb(0, 0, 0);
+  background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22%23007CB2%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.5-3.5%205.4-7.8%205.4-12.8%200-5-1.9-9.2-5.5-12.8z%22%2F%3E%3C%2Fsvg%3E'),
+    linear-gradient(to bottom, rgb(0, 0, 0) 0%, rgba(201, 141, 30, 0.5) 100%);
+  background-repeat: no-repeat, repeat;
+  background-position: right 0.7em top 50%, 0 0;
+  background-size: 0.65em auto, 100%;
+}
+.select-css::-ms-expand {
+  display: none;
+}
+.select-css:hover {
+  border-color: #888;
+}
+.select-css:focus {
+  border-color: #aaa;
+  box-shadow: 0 0 1px 3px rgba(255, 255, 255, 0.7);
+  box-shadow: 0 0 0 3px -moz-mac-focusring;
+  color: rgb(255, 255, 255);
+  outline: none;
+}
+.select-css option {
+  font-weight: normal;
+}

--- a/src/components/Selectors/Type Of Maintenance/index.jsx
+++ b/src/components/Selectors/Type Of Maintenance/index.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import './index.css';
+
+const TypeofMaintenance = () => (
+  <div>
+    <select className="select-css-maintenance">
+      <option value="none">Request</option>
+      <option value="Engine">Engine</option>
+      <option value="Exhaust">Exhaust</option>
+      <option value="Oil Change">Oil Change</option>
+      <option value="Checkup">Checkup</option>
+      <option value="Other">Other</option>
+    </select>
+  </div>
+);
+
+export default TypeofMaintenance;

--- a/src/components/Selectors/Type Of Paint/index.css
+++ b/src/components/Selectors/Type Of Paint/index.css
@@ -1,0 +1,41 @@
+.select-css-paint {
+  display: block;
+  font-size: 16px;
+  flex-direction: column;
+  font-family: sans-serif;
+  font-weight: 700;
+  color: rgb(255, 255, 255);
+  line-height: 1.3;
+  padding: 0.6em 1.4em 0.5em 0.8em;
+  width: 275.188px;
+  max-width: 275.188px;
+  box-sizing: border-box;
+  border: 1px solid rgb(0, 0, 0);
+  box-shadow: 0 1px 0 1px rgba(0, 0, 0, 0.04);
+  border-radius: 0.5em;
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  appearance: none;
+  background-color: rgb(0, 0, 0);
+  background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22%23007CB2%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.5-3.5%205.4-7.8%205.4-12.8%200-5-1.9-9.2-5.5-12.8z%22%2F%3E%3C%2Fsvg%3E'),
+    linear-gradient(to bottom, rgb(0, 0, 0) 0%, rgb(150, 73, 173, 0.5) 100%);
+  background-repeat: no-repeat, repeat;
+  background-position: right 0.7em top 50%, 0 0;
+  background-size: 0.65em auto, 100%;
+}
+.select-css::-ms-expand {
+  display: none;
+}
+.select-css:hover {
+  border-color: #888;
+}
+.select-css:focus {
+  border-color: #aaa;
+  box-shadow: 0 0 1px 3px rgba(255, 255, 255, 0.7);
+  box-shadow: 0 0 0 3px -moz-mac-focusring;
+  color: rgb(255, 255, 255);
+  outline: none;
+}
+.select-css option {
+  font-weight: normal;
+}

--- a/src/components/Selectors/Type Of Paint/index.jsx
+++ b/src/components/Selectors/Type Of Paint/index.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import './index.css';
+
+const TypeofPaint = () => (
+  <div>
+    <select className="select-css-paint">
+      <option value="none">Request</option>
+      <option value="Body Repair">Body Repair</option>
+      <option value="Stickers">Stickers</option>
+      <option value="Interior">Interior Design Customisations</option>
+      <option value="Wrap">Wrap</option>
+      <option value="Other">Other</option>
+    </select>
+  </div>
+);
+
+export default TypeofPaint;


### PR DESCRIPTION
- Add dropdowns to gas/maintenance/paint shops pages 

Note:
- Dropdown's design is from w3schools (will do mine in the end of the project)
- Dropdowns will be refactored to a class with state (react way) in the end of the project

The website should now look like this:
![Capture](https://user-images.githubusercontent.com/52399476/62135537-0f951d00-b2eb-11e9-932c-0229c7456fe2.PNG)

